### PR TITLE
feat: add Dockerfile (WIP) and circle config (WIP)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,30 @@
+# Python CircleCI 2.0 configuration file
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
+      # TBD: how to make use of our existing Dockerfile?
+      - image: circleci/python:3.6.1
+      
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - type: setup-docker-engine
+      - type: shell
+
+      - run: |
+         docker login -u $DOCKER_USER -p $DOCKER_PASS
+      # build the application image
+      - run: | 
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              docker build -t firefoxtesteng/firefox-nightly-source:latest .
+              docker push firefoxtesteng/firefox-nightly-source:latest
+            else
+              docker build -t firefoxtesteng/firefox-nightly-source:$CIRCLE_BRANCH .
+              docker push firefoxtesteng/firefox-nightly-source:$CIRCLE_BRANCH
+            fi

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.DS_Store
+*.sw[op]
+*.pyc
+__pycache__
+.cache
+.tox
+README.md
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+*.sw[op]
+*.pyc
+__pycache__
+.cache
+.tox

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Pull base image.
+FROM ubuntu:14.04
+
+WORKDIR /mozilla-central
+
+RUN sudo apt-get -y update && \
+    sudo apt-get -y install mercurial wget &&  \
+    apt-get -y --purge dist-upgrade && \
+    apt-get -y --purge autoremove -qq && \
+    apt-get clean -y
+
+# update to latest nightly Firefox
+RUN rm -rf firefox-nightly && \
+    wget -O firefox-nightly.tar.bz2 'https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US' && \
+    tar xjf firefox-nightly.tar.bz2 && \
+    rm -rf firefox-nightly.tar.bz2 && \
+    mv -i firefox firefox-nightly
+
+CMD ["ls -la /mozilla-central/firefox-nightly"]


### PR DESCRIPTION
@pdehaan   I did get part of the Firefox nightly source code loaded into the image, but I think i still need to do an hg pull to grab the bulk of it. ( let's not merge just yet) 
Also, i borrowed the circle config from our dummy python project and i think we'd need to do some tweakage so that we use our Dockerfile to do setup, rather than do that within the circle config.
NOTE: we can transfer ownership of this to mozilla-central once it's working.